### PR TITLE
Implement dynamic createForm generation

### DIFF
--- a/Julio_SergioRodriguez/CODIGO/index.html
+++ b/Julio_SergioRodriguez/CODIGO/index.html
@@ -51,7 +51,7 @@
 
 		<aside id='div-menu'>
 			<ol>
-				<li class="opcionmenu"><span class="text_characteristic" onclick="validar = new characteristic();">	characteristic</span></li>
+				<li class="opcionmenu"><span class="text_characteristic" onclick="validar = new characteristic(); validar.inicializar();">	characteristic</span></li>
 				<li class="opcionmenu"><span class="text_funcionalidad" onclick="validar = new funcionalidad();">Funcionalidad</span></li>
 			</ol>
 		</aside>

--- a/Julio_SergioRodriguez/CODIGO/index.html
+++ b/Julio_SergioRodriguez/CODIGO/index.html
@@ -17,7 +17,7 @@
 
 		<!--<script type="text/javascript" src="./js_core/DOM_class.js"></script>
 		<script type="text/javascript" src="./js_base/EntidadAbstracta.js"></script>-->
-		<script type="text/javascript" src="../CODIGO/js_core/DOM_class.js"></script>º
+		<script type="text/javascript" src="../CODIGO/js_core/DOM_class.js"></script>
 		<script type="text/javascript" src="../CODIGO/js_base/Entidad_Abstract_class.js"></script>
 
 			<!-- aqui los ficheros implementados para la ET2 -->
@@ -35,6 +35,7 @@
 		<!-- este es el script que carga las librerias ajax que usamos para acceder al back -->
 		<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
 
+        <script type="text/javascript">var validar;</script>
 	</head>
 
 	<body onload="">

--- a/Julio_SergioRodriguez/CODIGO/js_app/characteristic.js
+++ b/Julio_SergioRodriguez/CODIGO/js_app/characteristic.js
@@ -1,7 +1,9 @@
 class characteristic extends EntidadAbstracta {
     constructor() {
-        this.entidad="characteristic";
-        this.estructura= characteristic_estructura;
-
+        super();
+        this.entidad = 'characteristic';
+        this.estructura = estructura_characteristic;
+        this.columnasamostrar = this.estructura.columnas_visibles_tabla;
+        this.datosespecialestabla = this.estructura.columnas_modificadas_tabla;
     }
 }


### PR DESCRIPTION
## Summary
- refactor `createForm` to use internal state instead of parameters
- dynamically generate forms for active action
- add wrapper methods to set form type and values
- link characteristic entity to index menu

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68513c07ae6c8325afac6d2fbfb4559a