### PR TITLE
Implement form generator and validation helpers

### DIFF
--- a/Julio_SergioRodriguez/CODIGO/index.html
+++ b/Julio_SergioRodriguez/CODIGO/index.html
@@ -57,7 +57,7 @@
 		<img src="./iconos/United-Kingdom.png" onclick="setLang('EN');" />
 
 		<img id="botonTEST" src="./iconos/TEST.png" onclick="validar.test_run();" />
-                <a href="API.html"><img src="/CODIGO/iconos/FILE.png" alt="API" /></a>
+                <a href="API.html"><img src="./iconos/FILE.png" alt="API" /></a>
 	</header>
 
 	<nav class='bordeado'><span class="text_titulo_menu" onclick="menu_work();">Opciones de ménu</span></nav>

--- a/Julio_SergioRodriguez/CODIGO/index.html
+++ b/Julio_SergioRodriguez/CODIGO/index.html
@@ -57,7 +57,7 @@
 		<img src="./iconos/United-Kingdom.png" onclick="setLang('EN');" />
 
 		<img id="botonTEST" src="./iconos/TEST.png" onclick="validar.test_run();" />
-                <a href="API.html"><img src="Julio_SergioRodriguez/CODIGO/iconos/FILE.png" alt="API" /></a>
+                <a href="API.html"><img src="/CODIGO/iconos/FILE.png" alt="API" /></a>
 	</header>
 
 	<nav class='bordeado'><span class="text_titulo_menu" onclick="menu_work();">Opciones de ménu</span></nav>
@@ -83,8 +83,8 @@
 		<div id="id_tabla_datos">
 
 			<div id="addysearch">
-				<img id="botonADD" src="./iconos/ADD.png" onclick="validar.createForm('ADD');" />
-				<img id="botonSEARCH" src="./iconos/SEARCH.png" onclick="validar.createForm('SEARCH');" />
+				<img id="botonADD" src="./iconos/ADD.png" onclick="validar.createForm_ADD();" />
+				<img id="botonSEARCH" src="./iconos/SEARCH.png" onclick="validar.createForm_SEARCH();" />
 
 				<select id="seleccioncolumnas" size="2" multiple>
 				</select>

--- a/Julio_SergioRodriguez/CODIGO/index.html
+++ b/Julio_SergioRodriguez/CODIGO/index.html
@@ -57,7 +57,7 @@
 		<img src="./iconos/United-Kingdom.png" onclick="setLang('EN');" />
 
 		<img id="botonTEST" src="./iconos/TEST.png" onclick="validar.test_run();" />
-		<a href="API.html"><img src="./iconos/FILE.png" alt="API" /></a>
+                <a href="API.html"><img src="Julio_SergioRodriguez/CODIGO/iconos/FILE.png" alt="API" /></a>
 	</header>
 
 	<nav class='bordeado'><span class="text_titulo_menu" onclick="menu_work();">Opciones de ménu</span></nav>

--- a/Julio_SergioRodriguez/CODIGO/js_base/Entidad_Abstract_class.js
+++ b/Julio_SergioRodriguez/CODIGO/js_base/Entidad_Abstract_class.js
@@ -187,7 +187,7 @@ class EntidadAbstracta extends DOM_class {
 			let texto = valoratributo;
 			texto += `<a id="link_file_characteristic" href="http://193.147.87.202/ET2/filesuploaded/files_file_characteristic/`;
 			texto += valoratributo;
-			texto += `"><img src="./iconos/FILE.png" /></a>`;
+                        texto += `"><img src="Julio_SergioRodriguez/CODIGO/iconos/FILE.png" /></a>`;
 
 			return texto;
 

--- a/Julio_SergioRodriguez/CODIGO/js_base/Entidad_Abstract_class.js
+++ b/Julio_SergioRodriguez/CODIGO/js_base/Entidad_Abstract_class.js
@@ -187,7 +187,7 @@ class EntidadAbstracta extends DOM_class {
 			let texto = valoratributo;
 			texto += `<a id="link_file_characteristic" href="http://193.147.87.202/ET2/filesuploaded/files_file_characteristic/`;
 			texto += valoratributo;
-                        texto += `"><img src="Julio_SergioRodriguez/CODIGO/iconos/FILE.png" /></a>`;
+                        texto += `"><img src="/CODIGO/iconos/FILE.png" /></a>`;
 
 			return texto;
 

--- a/Julio_SergioRodriguez/CODIGO/js_base/Entidad_Abstract_class.js
+++ b/Julio_SergioRodriguez/CODIGO/js_base/Entidad_Abstract_class.js
@@ -187,7 +187,7 @@ class EntidadAbstracta extends DOM_class {
 			let texto = valoratributo;
 			texto += `<a id="link_file_characteristic" href="http://193.147.87.202/ET2/filesuploaded/files_file_characteristic/`;
 			texto += valoratributo;
-                        texto += `"><img src="/CODIGO/iconos/FILE.png" /></a>`;
+                        texto += `"><img src="./iconos/FILE.png" /></a>`;
 
 			return texto;
 

--- a/Julio_SergioRodriguez/CODIGO/js_core/Dom_class.js
+++ b/Julio_SergioRodriguez/CODIGO/js_core/Dom_class.js
@@ -275,117 +275,135 @@ class DOM_class extends test {
 
 
     createForm(action) {
-        const validador = new Dom_validations();
+        this.tipo_formulario = action;
         document.getElementById('IU_form').innerHTML = '';
+
         if (typeof this.cargar_formulario_html === 'function') {
             this.cargar_formulario_html();
-
-        } else {
-            this.cargar_formulario_dinamico();
-            const inputs = document.querySelectorAll('#IU_form input, #IU_form textarea');
-
-            const validador = new Dom_validations();
-            for (const input of inputs) {
-                input.addEventListener('blur', () => {
-                    validador.comprobarCampo(
-                        input.id,
-                        action,
-                        this.estructura,
-                        this.validaciones
-                    );
-                });
-            }
-
+            return;
         }
-        const formEl = document.getElementById('IU_form');
-        if (!formEl) return;
-        console.log(formEl.querySelectorAll('input, textarea'));
-        for (let input of formEl.querySelectorAll('input, textarea, select')) {
 
-            if (!input) continue;
-            const atributo = input.id;
-            //autoincrementales
-            if (action === 'ADD' || action === 'EDIT') {
-                const autoIn = this.estructura?.attributes?.[atributo]?.is_autoincrement || false;
-                if (autoIn) {
-                    if (input) input.style.display = "none";
-                    const labelEl = document.querySelector(`label[for="${atributo}"]`);
-                    if (labelEl) labelEl.style.display = "none";
-                    const errorEl = document.getElementById(`div_error_${atributo}`);
-                    if (errorEl) errorEl.classList.add('hidden');
-                }
+        let formulario = '';
+        this.obtenerEstructura1().forEach(campo => {
+            if ((action === 'ADD' || action === 'EDIT') && campo.autoincrement) return;
+
+            if (campo.tipo === 'select') {
+                formulario += `\n        <label id="label_${campo.nombre}" class="label_${campo.nombre}"></label>`;
+                formulario += `\n        <select id="${campo.nombre}" name="${campo.nombre}">`;
+                formulario += campo.opciones.map(o => `<option value="${o}">${o}</option>`).join('');
+                formulario += `</select>`;
+                formulario += `\n        <span id="div_error_${campo.nombre}"><a id="error_${campo.nombre}"></a></span><br>`;
+                return;
             }
-            //ficheros
-            if (action === 'ADD' || action === 'SEARCH') {
-                const esfichero = (this.estructura?.attributes?.[atributo]?.html?.type) === 'file';
-                if (esfichero) {
-                    const linkEl = document.getElementById(`link_${atributo}`);
-                    if (linkEl) {
-                        linkEl.classList.add('hidden');
+
+            if (campo.tipo === 'file') {
+                formulario += `\n        <label id="label_${campo.nombre}" class="label_${campo.nombre}"></label>`;
+                formulario += `\n        <input type="text" id="${campo.nombre}" name="${campo.nombre}">`;
+                formulario += `\n        <span id="div_error_${campo.nombre}"><a id="error_${campo.nombre}"></a></span>`;
+                formulario += `\n        <a id="link_${campo.nombre}" href="http://193.147.87.202/ET2/filesuploaded/files_${campo.nombre}/">`;
+                formulario += `\n          <img src="/CODIGO/iconos/FILE.png">`;
+                formulario += `\n        </a>`;
+                formulario += `\n        <label id="label_nuevo_${campo.nombre}" class="label_nuevo_${campo.nombre}"></label>`;
+                formulario += `\n        <input type="file" id="nuevo_${campo.nombre}" name="nuevo_${campo.nombre}">`;
+                formulario += `\n        <span id="div_error_nuevo_${campo.nombre}"><a id="error_nuevo_${campo.nombre}"></a></span><br>`;
+                return;
+            }
+
+            if (campo.tipo === 'textarea') {
+                formulario += `\n        <label id="label_${campo.nombre}" class="label_${campo.nombre}"></label>`;
+                formulario += `\n        <textarea id="${campo.nombre}" name="${campo.nombre}" rows="${campo.filas || 5}" cols="${campo.columnas || 40}"></textarea>`;
+                formulario += `\n        <span id="div_error_${campo.nombre}"><a id="error_${campo.nombre}"></a></span><br>`;
+                return;
+            }
+
+            formulario += `\n      <label id="label_${campo.nombre}" class="label_${campo.nombre}"></label>`;
+            formulario += `\n      <input type="${campo.tipo}" id="${campo.nombre}" name="${campo.nombre}">`;
+            formulario += `\n      <span id="div_error_${campo.nombre}"><a id="error_${campo.nombre}"></a></span><br>`;
+        });
+
+        document.getElementById('IU_form').innerHTML = formulario;
+    }
+
+    obtenerEstructura1() {
+        const atributos = this.estructura?.attributes_list || [];
+        const resultado = [];
+        for (const attr of atributos) {
+            const conf = this.estructura?.attributes?.[attr] || {};
+            const html = conf.html || {};
+            resultado.push({
+                nombre: attr,
+                tipo: html.type || html.tag || 'text',
+                opciones: html.options || [],
+                filas: html.rows,
+                columnas: html.columns,
+                autoincrement: conf.is_autoincrement === 'true'
+            });
+        }
+        return resultado;
+    }
+
+    obtenerEstructura2() {
+        const res = {};
+        const atributos = this.estructura?.attributes || {};
+        for (const [attr, conf] of Object.entries(atributos)) {
+            if (!conf.validation_rules) continue;
+            for (const [accion, reglas] of Object.entries(conf.validation_rules)) {
+                if (!res[accion]) res[accion] = {};
+                res[accion][attr] = {};
+                for (const [regla, valor] of Object.entries(reglas)) {
+                    if (Array.isArray(valor)) {
+                        res[accion][attr][regla] = { valor: valor[0], code: valor[1] };
+                    } else {
+                        res[accion][attr][regla] = { valor: valor, code: valor };
                     }
                 }
             }
-
-            if (action === 'ADD') {
-                const esfichero = (this.estructura?.attributes?.[atributo]?.html?.type) === 'file';
-                if (esfichero) {
-                    if (input) input.classList.add('hidden');
-                    const labelEl = document.querySelector(`label[for="${atributo}"]`);
-                    if (labelEl) labelEl.classList.add('hidden');
-                    const errorEl = document.getElementById(`div_error_${atributo}`);
-                    if (errorEl) errorEl.classList.add('hidden');
-                }
-            }
-
-            if (action === 'SEARCH' || action === 'SHOWCURRENT' || action === 'DELETE') {
-                if (atributo.startsWith('nuevo_') || atributo.startsWith('foto_')) {
-                    if (input) input.classList.add('hidden');
-                    const labelEl = document.querySelector(`label[for="${atributo}"]`);
-                    if (labelEl) labelEl.classList.add('hidden');
-                    const errorEl = document.getElementById(`div_error_${atributo}`);
-                    if (errorEl) errorEl.classList.add('hidden');
-                }
-            }
-
-            input.addEventListener('blur', () => {
-                validador.submit_test(
-                    input.id,
-                    action,
-                    this.estructura,
-                    validador.atomicValidations,
-                    console.log('aaaaaaaaaa'),
-                );
-            });
         }
-        //colocar botones 
+        return res;
+    }
 
-        switch (action) {
-            case 'ADD':
-                document.getElementById('IU_form').innerHTML += `<button type="button" id="submit_button" onclick="wiga = new Dom_validations(); wiga.submit_test('ADD')">niger</button>`;
-                break;
-            case 'EDIT':
-                document.getElementById('IU_form').innerHTML += `<button type="button" id="submit_button" onclick="validar.Dom_validations.submit_test('EDIT','this')">niger</button>`;
-                break;
-
-            /*
-        case 'SEARCH':
-            document.getElementById('IU_form').innerHTML += `<button type="submit" id="submit_button" class="btn btn-primary">${this.textos['text_contenido_boton_submit_SEARCH']}</button>`;
-            break;
-        case 'EDIT':
-            document.getElementById('IU_form').innerHTML += `<button type="submit" id="submit_button" class="btn btn-primary">${this.textos['text_contenido_boton_submit_EDIT']}</button>`;
-            break;
-        case 'DELETE':
-            document.getElementById('IU_form').innerHTML += `<button type="submit" id="submit_button" class="btn btn-primary">${this.textos['text_contenido_boton_submit_DELETE']}</button>`;
-            break;
-*/
-
+    comprobarCampo(accion, campo) {
+        const campoReal = campo.startsWith('nuevo_') ? campo.slice(6) : campo;
+        const tests = this.obtenerEstructura2()?.[accion]?.[campoReal] || {};
+        for (const tipo in tests) {
+            const { valor, code } = tests[tipo];
+            switch (tipo) {
+                case 'min_size':
+                    if (!this.validaciones.min_size(campo, valor)) return this.mostrar_error_campo(campo, code);
+                    break;
+                case 'max_size':
+                    if (!this.validaciones.max_size(campo, valor)) return this.mostrar_error_campo(campo, code);
+                    break;
+                case 'format':
+                    if (!this.validaciones.format(campo, valor)) return this.mostrar_error_campo(campo, code);
+                    break;
+                case 'no_file':
+                    if (!this.validaciones.no_file(document.getElementById(`nuevo_${campoReal}`).files[0]))
+                        return this.mostrar_error_campo(campo, code);
+                    break;
+                case 'file_type':
+                    if (!this.validaciones.type_file(document.getElementById(`nuevo_${campoReal}`).files[0], valor))
+                        return this.mostrar_error_campo(campo, code);
+                    break;
+                case 'max_size_file':
+                    if (!this.validaciones.max_size_file(document.getElementById(`nuevo_${campoReal}`).files[0], valor))
+                        return this.mostrar_error_campo(campo, code);
+                    break;
+                case 'format_name_file':
+                    if (!this.validaciones.format_name_file(document.getElementById(`nuevo_${campoReal}`).files[0], valor))
+                        return this.mostrar_error_campo(campo, code);
+                    break;
+                case 'personalize':
+                    const vals = Array.from(document.forms['IU_form'].elements)
+                        .reduce((o, el) => { o[el.id] = el.value; return o; }, {});
+                    const fn = window[valor];
+                    if (typeof fn === 'function' && !fn(vals))
+                        return this.mostrar_error_campo(campo, code);
+                    break;
+            }
         }
-
-
-
-
-
-
+        this.mostrar_exito_campo(campo);
+        return true;
     }
 
     cargar_formulario_dinamico() {

--- a/Julio_SergioRodriguez/CODIGO/js_core/Dom_class.js
+++ b/Julio_SergioRodriguez/CODIGO/js_core/Dom_class.js
@@ -301,7 +301,7 @@ class DOM_class extends test {
                 formulario += `\n        <input type="text" id="${campo.nombre}" name="${campo.nombre}">`;
                 formulario += `\n        <span id="div_error_${campo.nombre}"><a id="error_${campo.nombre}"></a></span>`;
                 formulario += `\n        <a id="link_${campo.nombre}" href="http://193.147.87.202/ET2/filesuploaded/files_${campo.nombre}/">`;
-                formulario += `\n          <img src="/CODIGO/iconos/FILE.png">`;
+                formulario += `\n          <img src="./iconos/FILE.png">`;
                 formulario += `\n        </a>`;
                 formulario += `\n        <label id="label_nuevo_${campo.nombre}" class="label_nuevo_${campo.nombre}"></label>`;
                 formulario += `\n        <input type="file" id="nuevo_${campo.nombre}" name="nuevo_${campo.nombre}">`;

--- a/Julio_SergioRodriguez/CODIGO/js_core/Dom_class.js
+++ b/Julio_SergioRodriguez/CODIGO/js_core/Dom_class.js
@@ -300,7 +300,7 @@ class DOM_class extends test {
                 formulario += `\n        <input type="text" id="${campo.nombre}" name="${campo.nombre}">`;
                 formulario += `\n        <span id="div_error_${campo.nombre}"><a id="error_${campo.nombre}"></a></span>`;
                 formulario += `\n        <a id="link_${campo.nombre}" href="http://193.147.87.202/ET2/filesuploaded/files_${campo.nombre}/">`;
-                formulario += `\n          <img src="/CODIGO/iconos/FILE.png">`;
+                formulario += `\n          <img src="./iconos/FILE.png">`;
                 formulario += `\n        </a>`;
                 formulario += `\n        <label id="label_nuevo_${campo.nombre}" class="label_nuevo_${campo.nombre}"></label>`;
                 formulario += `\n        <input type="file" id="nuevo_${campo.nombre}" name="nuevo_${campo.nombre}">`;
@@ -324,8 +324,11 @@ class DOM_class extends test {
     }
 
     obtenerEstructura1() {
-        const nombreVariable = `estructura_${this.entidad}`;
-        const estructura = window[nombreVariable];
+        let estructura = this.estructura;
+        if (!estructura) {
+            const nombreVariable = `estructura_${this.entidad}`;
+            estructura = globalThis[nombreVariable];
+        }
         if (!estructura) return [];
 
         return estructura.attributes_list.map(nombre => {
@@ -350,8 +353,11 @@ class DOM_class extends test {
     }
 
     obtenerEstructura2() {
-        const nombreVariable = `estructura_${this.entidad}`;
-        const estructura = window[nombreVariable];
+        let estructura = this.estructura;
+        if (!estructura) {
+            const nombreVariable = `estructura_${this.entidad}`;
+            estructura = globalThis[nombreVariable];
+        }
         if (!estructura) return {};
 
         const res = {};

--- a/Julio_SergioRodriguez/CODIGO/js_core/Dom_class.js
+++ b/Julio_SergioRodriguez/CODIGO/js_core/Dom_class.js
@@ -274,8 +274,7 @@ class DOM_class extends test {
     }
 
 
-    createForm(action) {
-        this.tipo_formulario = action;
+    createForm() {
         document.getElementById('IU_form').innerHTML = '';
 
         if (typeof this.cargar_formulario_html === 'function') {
@@ -285,7 +284,7 @@ class DOM_class extends test {
 
         let formulario = '';
         this.obtenerEstructura1().forEach(campo => {
-            if ((action === 'ADD' || action === 'EDIT') && campo.autoincrement) return;
+            if ((this.tipo_accion === 'ADD' || this.tipo_accion === 'EDIT') && campo.autoincrement) return;
 
             if (campo.tipo === 'select') {
                 formulario += `\n        <label id="label_${campo.nombre}" class="label_${campo.nombre}"></label>`;
@@ -301,7 +300,7 @@ class DOM_class extends test {
                 formulario += `\n        <input type="text" id="${campo.nombre}" name="${campo.nombre}">`;
                 formulario += `\n        <span id="div_error_${campo.nombre}"><a id="error_${campo.nombre}"></a></span>`;
                 formulario += `\n        <a id="link_${campo.nombre}" href="http://193.147.87.202/ET2/filesuploaded/files_${campo.nombre}/">`;
-                formulario += `\n          <img src="Julio_SergioRodriguez/CODIGO/iconos/FILE.png">`;
+                formulario += `\n          <img src="/CODIGO/iconos/FILE.png">`;
                 formulario += `\n        </a>`;
                 formulario += `\n        <label id="label_nuevo_${campo.nombre}" class="label_nuevo_${campo.nombre}"></label>`;
                 formulario += `\n        <input type="file" id="nuevo_${campo.nombre}" name="nuevo_${campo.nombre}">`;
@@ -410,7 +409,7 @@ class DOM_class extends test {
         /*
         const estructura = this.estructura;
         let formulario = '';
-        const accion = this.tipo_formulario || 'ADD';
+        const accion = this.tipo_accion || 'ADD';
 
         for (const atributo of estructura.attributes_list) {
             const config = estructura.attributes[atributo];
@@ -510,31 +509,31 @@ class DOM_class extends test {
     }
 
     createForm_ADD() {
-        this.tipo_formulario = 'ADD';
+        this.tipo_accion = 'ADD';
         this.form_values = null;
         this.createForm();
     }
 
     createForm_SEARCH() {
-        this.tipo_formulario = 'SEARCH';
+        this.tipo_accion = 'SEARCH';
         this.form_values = null;
         this.createForm();
     }
 
     createForm_EDIT(values) {
-        this.tipo_formulario = 'EDIT';
+        this.tipo_accion = 'EDIT';
         this.form_values = values;
         this.createForm();
     }
 
     createForm_DELETE(values) {
-        this.tipo_formulario = 'DELETE';
+        this.tipo_accion = 'DELETE';
         this.form_values = values;
         this.createForm();
     }
 
     createForm_SHOWCURRENT(values) {
-        this.tipo_formulario = 'SHOWCURRENT';
+        this.tipo_accion = 'SHOWCURRENT';
         this.form_values = values;
         this.createForm();
     }

--- a/Julio_SergioRodriguez/CODIGO/js_core/Dom_class.js
+++ b/Julio_SergioRodriguez/CODIGO/js_core/Dom_class.js
@@ -301,7 +301,7 @@ class DOM_class extends test {
                 formulario += `\n        <input type="text" id="${campo.nombre}" name="${campo.nombre}">`;
                 formulario += `\n        <span id="div_error_${campo.nombre}"><a id="error_${campo.nombre}"></a></span>`;
                 formulario += `\n        <a id="link_${campo.nombre}" href="http://193.147.87.202/ET2/filesuploaded/files_${campo.nombre}/">`;
-                formulario += `\n          <img src="./iconos/FILE.png">`;
+                formulario += `\n          <img src="Julio_SergioRodriguez/CODIGO/iconos/FILE.png">`;
                 formulario += `\n        </a>`;
                 formulario += `\n        <label id="label_nuevo_${campo.nombre}" class="label_nuevo_${campo.nombre}"></label>`;
                 formulario += `\n        <input type="file" id="nuevo_${campo.nombre}" name="nuevo_${campo.nombre}">`;

--- a/Julio_SergioRodriguez/CODIGO/js_core/Dom_class.js
+++ b/Julio_SergioRodriguez/CODIGO/js_core/Dom_class.js
@@ -324,15 +324,12 @@ class DOM_class extends test {
     }
 
     obtenerEstructura1() {
-        let estructura = this.estructura;
-        if (!estructura) {
-            const nombreVariable = `estructura_${this.entidad}`;
-            estructura = globalThis[nombreVariable];
-        }
+        const nombreVariable = `estructura_${this.entidad}`;
+        const estructura = window[nombreVariable];
         if (!estructura) return [];
 
         return estructura.attributes_list.map(nombre => {
-            const def = estructura.attributes[nombre] || {};
+            const def = estructura.attributes[nombre];
             const html = def.html || {};
 
             let tipo = 'text';
@@ -353,11 +350,8 @@ class DOM_class extends test {
     }
 
     obtenerEstructura2() {
-        let estructura = this.estructura;
-        if (!estructura) {
-            const nombreVariable = `estructura_${this.entidad}`;
-            estructura = globalThis[nombreVariable];
-        }
+        const nombreVariable = `estructura_${this.entidad}`;
+        const estructura = window[nombreVariable];
         if (!estructura) return {};
 
         const res = {};

--- a/Julio_SergioRodriguez/CODIGO/js_core/Dom_class.js
+++ b/Julio_SergioRodriguez/CODIGO/js_core/Dom_class.js
@@ -324,26 +324,38 @@ class DOM_class extends test {
     }
 
     obtenerEstructura1() {
-        const atributos = this.estructura?.attributes_list || [];
-        const resultado = [];
-        for (const attr of atributos) {
-            const conf = this.estructura?.attributes?.[attr] || {};
-            const html = conf.html || {};
-            resultado.push({
-                nombre: attr,
-                tipo: html.type || html.tag || 'text',
+        const nombreVariable = `estructura_${this.entidad}`;
+        const estructura = window[nombreVariable];
+        if (!estructura) return [];
+
+        return estructura.attributes_list.map(nombre => {
+            const def = estructura.attributes[nombre] || {};
+            const html = def.html || {};
+
+            let tipo = 'text';
+            if (html.tag === 'select') tipo = 'select';
+            else if (html.tag === 'textarea') tipo = 'textarea';
+            else if (html.tag === 'input') tipo = html.type || 'text';
+
+            return {
+                nombre,
+                tipo,
+                autoincrement: !!def.is_autoincrement,
                 opciones: html.options || [],
-                filas: html.rows,
-                columnas: html.columns,
-                autoincrement: conf.is_autoincrement === 'true'
-            });
-        }
-        return resultado;
+                filas: html.rows || null,
+                columnas: html.columns || null,
+                validation_rules: def.validation_rules || {}
+            };
+        });
     }
 
     obtenerEstructura2() {
+        const nombreVariable = `estructura_${this.entidad}`;
+        const estructura = window[nombreVariable];
+        if (!estructura) return {};
+
         const res = {};
-        const atributos = this.estructura?.attributes || {};
+        const atributos = estructura.attributes || {};
         for (const [attr, conf] of Object.entries(atributos)) {
             if (!conf.validation_rules) continue;
             for (const [accion, reglas] of Object.entries(conf.validation_rules)) {

--- a/Julio_SergioRodriguez/CODIGO/js_core/Dom_validations_class.js
+++ b/Julio_SergioRodriguez/CODIGO/js_core/Dom_validations_class.js
@@ -115,7 +115,7 @@ class Dom_validations {
                                 case 'max_size_file': {
                                         const file = document.getElementById(campo).files[0];
                                         if (!file || !atomicValidations.max_size_file(file, valor[0])) {
-                                                thismostrar_error_campo(campo, valor[1]);
+                                                this.mostrar_error_campo(campo, valor[1]);
                                                 return valor[1];
                                         }
                                         break;


### PR DESCRIPTION
## Summary
- simplify `createForm` to build form components based on the new structure
- expose helpers `obtenerEstructura1`, `obtenerEstructura2` and a new `comprobarCampo`
- fix a typo in `Dom_validations_class`

## Testing
- `node -e "require('./Julio_SergioRodriguez/CODIGO/js_core/Dom_class.js')"` *(fails: `ReferenceError: test is not defined`)*

------
https://chatgpt.com/codex/tasks/task_e_685ec7cfa2c48325b759c9607c1ee30e